### PR TITLE
Linux compilation fix and set angle fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default: lib
 
-CC      := gcc
-CXX 	:= g++
+CC      ?= cc
+CXX     ?= c++
 CFLAGS  := -g -Wall -fPIC -DSM64_LIB_EXPORT -DVERSION_US -DNO_SEGMENTED_MEMORY -DGBI_FLOATS
 LDFLAGS := -lm -shared -lpthread
 ENDFLAGS := -fPIC
@@ -39,7 +39,7 @@ ifeq ($(OS),Windows_NT)
   LIB_FILE := $(DIST_DIR)/sm64.dll
 endif
 
-DUMMY != mkdir -p $(ALL_DIRS) build/test src/decomp/mario $(DIST_DIR)/include 
+DUMMY != mkdir -p $(ALL_DIRS) build/test src/decomp/mario $(DIST_DIR)/include
 
 
 $(BUILD_DIR)/%.o: %.c $(IMPORTED)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default: lib
 
-CC      ?= cc
-CXX     ?= c++
+CC      := cc
+CXX     := c++
 CFLAGS  := -g -Wall -fPIC -DSM64_LIB_EXPORT -DVERSION_US -DNO_SEGMENTED_MEMORY -DGBI_FLOATS
 LDFLAGS := -lm -shared -lpthread
 ENDFLAGS := -fPIC

--- a/src/decomp/pc/audio/audio_pulse.c
+++ b/src/decomp/pc/audio/audio_pulse.c
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include <pulse/pulseaudio.h>
 
-#include "macros.h"
+#include <macros.h>
 #include "audio_api.h"
 
 static struct {

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -398,7 +398,7 @@ SM64_LIB_FN void sm64_set_mario_angle(int32_t marioId, float angle)
 	struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
 	
-	gMarioState->faceAngle[1] = (short)(angle * (32768.0f * 3.14159f));
+	gMarioState->faceAngle[1] = (short)(angle * (32768.0f / 3.14159f));
 	gMarioState->marioObj->header.gfx.angle[1] = (short)(angle * (32768.0f * 3.14159f));
 }
 

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -399,7 +399,7 @@ SM64_LIB_FN void sm64_set_mario_angle(int32_t marioId, float angle)
     global_state_bind( globalState );
 	
 	gMarioState->faceAngle[1] = (short)(angle * (32768.0f / 3.14159f));
-	gMarioState->marioObj->header.gfx.angle[1] = (short)(angle * (32768.0f * 3.14159f));
+	gMarioState->marioObj->header.gfx.angle[1] = (short)(angle * (32768.0f / 3.14159f));
 }
 
 SM64_LIB_FN void sm64_set_mario_velocity(int32_t marioId, float x, float y, float z)


### PR DESCRIPTION
First of all, thank you for this fork of libsm64, it`s been very helpfull for my project; https://github.com/Brawmario/libsm64-godot

This pull request cointains a couple of fixes

First header fix fixes compilation on Linux, the macros.h header include needs to be in brackets since this header isn't in the same directory where it's being included, wouldn`t compile on Github Actions for me without this.

The second fixes the set mario angle to be equivalent to the face angle returned in the Mario Tick function. In the Mario Tick function, the intenal angle is divided by 32768.0f and multplied by 3.14159f, so when setting the angle it only makes sense for the value to be then multiplied by 32768.0f and divided by 3.14159f, the opposite operation

